### PR TITLE
Unescaping uri

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -587,16 +587,20 @@ impl VideoPlayerInner {
                 let window_clone = Fragile::new(ui_ctx.window.clone());
                 ctx.player
                     .connect_media_info_updated(clone_army!([file_list, inner] move |player, info| {
-                        let uri = info.get_uri();
+                        let uri = &info.get_uri();
                         let mut file_list = file_list.lock().unwrap();
                         // Call this only once per asset.
-                        if !&file_list.contains(&uri) {
+                        if !&file_list.contains(uri) {
                             file_list.push(uri.clone());
                             let window = &*window_clone.get();
                             if let Some(title) = info.get_title() {
                                 window.set_title(&*title);
                             } else {
-                                window.set_title(&*info.get_uri());
+                                if let Ok((filename, _)) = glib::filename_from_uri(uri) {
+                                    window.set_title(&filename.as_os_str().to_string_lossy());
+                                } else {
+                                    window.set_title(uri);
+                                }
                             }
 
                             let inner = &*inner.get();


### PR DESCRIPTION
Hello all,

This PR just tries to unescape (or percent decode) the file URI before passing to the player, that allows a more friendly name on the title bar. E.g. before escaping:

![capture du 2018-07-23 13-19-34](https://user-images.githubusercontent.com/79418/43074510-ceee2fb8-8e7d-11e8-94ec-c3fdd122a8cf.png)

after escaping:

![capture du 2018-07-23 13-20-57](https://user-images.githubusercontent.com/79418/43074518-d7122604-8e7d-11e8-9281-7177f731780c.png)

Personally, I just do it to see the name of playing file better, so it maybe is not important (and feel free to reject it if you don't want) but many thanks for any feedback.