### PR TITLE
scripts: Require bash for bash extension [[

### DIFF
--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export CARGO_HOME=$1/target/cargo-home
 


### PR DESCRIPTION
We need a Bash shell for the [[ syntax.
See https://www.gnu.org/software/bash/manual/html_node/Conditional-Constructs.html#index-_005b_005b.

Fixes #24