### PR TITLE
main: Respect default subtitle stream

### DIFF
--- a/src/channel_player.rs
+++ b/src/channel_player.rs
@@ -576,6 +576,10 @@ impl ChannelPlayer {
         self.player.set_subtitle_track_enabled(enabled);
     }
 
+    pub fn get_current_subtitle_track(&self) -> Option<gst_player::PlayerSubtitleInfo> {
+        self.player.get_current_subtitle_track()
+    }
+
     pub fn get_subtitle_uri(&self) -> Option<glib::GString> {
         self.player.get_subtitle_uri()
     }


### PR DESCRIPTION
Before this change, if the media has a default subtitle stream, it would be
cleared out by us because a false-positive "sub-none" action would be triggered
during the subtitles menu building.