### PR TITLE
Cargo: Properly specify structopt version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = "0.9"
-structopt = "*"
+structopt = "0.3"
 
 [dependencies.gstreamer]
 features = ["v1_16"]


### PR DESCRIPTION
crates.io doesn't accept "*".