### PR TITLE
fix progress bar sometimes not displaying right

### DIFF
--- a/src/channel_player.rs
+++ b/src/channel_player.rs
@@ -48,6 +48,7 @@ pub struct AudioVisualization(pub string::String);
 #[derive(Serialize, Deserialize, Clone)]
 pub enum PlayerEvent {
     MediaInfoUpdated,
+    DurationChanged(Option<gst::ClockTime>),
     PositionUpdated,
     EndOfStream(string::String),
     EndOfPlaylist,
@@ -294,6 +295,11 @@ impl ChannelPlayer {
                             player_data.media_info_updated(&info);
                         });
 
+                    }
+                    PlayMessage::DurationChanged { duration } => {
+                        with_player!(player {
+                            player.notify(PlayerEvent::DurationChanged(duration));
+                        });
                     }
                     PlayMessage::PositionUpdated { position: _ } => {
                         with_player!(player {

--- a/src/main.rs
+++ b/src/main.rs
@@ -587,6 +587,9 @@ impl VideoPlayer {
             PlayerEvent::MediaInfoUpdated => {
                 self.media_info_updated();
             }
+            PlayerEvent::DurationChanged(duration) => {
+                self.duration_changed(duration);
+            }
             PlayerEvent::PositionUpdated => {
                 self.position_updated();
             }
@@ -687,6 +690,12 @@ impl VideoPlayer {
                 self.ui_context.clear_audio_visualization_menu();
                 self.audio_visualization_action.set_enabled(false);
             }
+        }
+    }
+
+    pub fn duration_changed(&self, duration: Option<gst::ClockTime>) {
+        if let Some(dur) = duration {
+            self.ui_context.set_position_range_end(dur.seconds() as f64);
         }
     }
 


### PR DESCRIPTION
I've been having an issue where the progress bar is hidden and showing a value of "00:00" sometimes when opening an audio file that is longer than about 40 minutes. Sometimes it will work as expected with the same file.

As far as I can tell, it seems to be related to the threading of `GstPlayMediaInfo.duration` assignment in the gstreamer backend.

Reading the duration value direction from the `GstPlay` object seems to fix the issue without causing any problems.