### PR TITLE
Present window on activation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -202,7 +202,11 @@ impl VideoPlayer {
             })
         });
 
-        gtk_app.connect_activate(|_| {});
+        gtk_app.connect_activate(|_| {
+            with_video_player!(video_player {
+                video_player.ui_context.present();
+            });
+        });
 
         let quit = gio::SimpleAction::new("quit", None);
         quit.connect_activate(|_, _| {

--- a/src/ui_context.rs
+++ b/src/ui_context.rs
@@ -349,6 +349,10 @@ impl UIContext {
         window.set_cursor(cursor.as_ref());
     }
 
+    pub fn present(&self) {
+        self.window.present();
+    }
+
     #[allow(deprecated)]
     pub fn open_dialog<F>(&self, relative_uri: Option<glib::GString>, f: F)
     where


### PR DESCRIPTION
This ensures that the main window brings to the front on launch if the application is already running.