### PR TITLE
Set application for the window

### DIFF
--- a/src/ui_context.rs
+++ b/src/ui_context.rs
@@ -382,6 +382,7 @@ impl UIContext {
     }
 
     pub fn start<F: Fn() + Send + Sync + 'static>(&self, f: F) {
+        self.window.set_application(Some(&self.app));
         self.window.set_visible(true);
         self.window.connect_close_request(move |_| {
             f();


### PR DESCRIPTION
This ensures that the window has the proper toplevel ID, and Wayland compositors could match the window with the desktop file and show the appriopiate icon for it.